### PR TITLE
linux-vs-freebsd-vs-openbsd: sources: suggested changes

### DIFF
--- a/content/posts/linux-vs-freebsd-vs-openbsd.md
+++ b/content/posts/linux-vs-freebsd-vs-openbsd.md
@@ -98,6 +98,6 @@ Thanks for reading and a special *thank you* to everyone who helped on Reddit, l
 - [Quare FreeBSD](https://vermaden.wordpress.com/2020/09/07/quare-freebsd/) – <https://redd.it/inwclo> | <https://news.ycombinator.com/item?id=31664952>
 - [Alpine Linux](https://alpinelinux.org/about/)
 - [OpenBSD Goals](https://www.openbsd.org/goals.html)
-- [OpenBSD Why Use](https://www.openbsd.org/faq/faq1.html#WhyUse)
+- [OpenBSD FAQ: Introduction to OpenBSD](https://www.openbsd.org/faq/faq1.html)
 - FreeBSD Project [goal](https://docs.freebsd.org/en/books/faq/#FreeBSD-goals) and [features](https://www.freebsd.org/features/)
 

--- a/content/posts/linux-vs-freebsd-vs-openbsd.md
+++ b/content/posts/linux-vs-freebsd-vs-openbsd.md
@@ -95,7 +95,7 @@ Thanks for reading and a special *thank you* to everyone who helped on Reddit, l
 
 - Smart people on Reddit – <https://redd.it/1dbxxyb>, <https://redd.it/1dbxz0r>
 - [Old YT playlist (some good points there)](https://www.youtube.com/playlist?list=PLdArachVKgnZ4-RPot9EbKBdyR4qtzIOo)
-- [Quare FreeBSD](https://vermaden.wordpress.com/2020/09/07/quare-freebsd/)
+- [Quare FreeBSD](https://vermaden.wordpress.com/2020/09/07/quare-freebsd/) – <https://redd.it/inwclo> | <https://news.ycombinator.com/item?id=31664952>
 - [Alpine Linux](https://alpinelinux.org/about/)
 - [OpenBSD Goals](https://www.openbsd.org/goals.html)
 - [OpenBSD Why Use](https://www.openbsd.org/faq/faq1.html#WhyUse)

--- a/content/posts/linux-vs-freebsd-vs-openbsd.md
+++ b/content/posts/linux-vs-freebsd-vs-openbsd.md
@@ -93,7 +93,7 @@ Thanks for reading and a special *thank you* to everyone who helped on Reddit, l
 
 ## Sources
 
-- [Smart people on Reddit](https://www.reddit.com/r/BSD/comments/1dbxxyb/linux_to_bsd_whats_really_the_difference/)
+- Smart people on Reddit – <https://redd.it/1dbxxyb>, <https://redd.it/1dbxz0r>
 - [Old YT playlist (some good points there)](https://www.youtube.com/playlist?list=PLdArachVKgnZ4-RPot9EbKBdyR4qtzIOo)
 - [Quare FreeBSD](https://vermaden.wordpress.com/2020/09/07/quare-freebsd/)
 - [Alpine Linux](https://alpinelinux.org/about/)

--- a/content/posts/linux-vs-freebsd-vs-openbsd.md
+++ b/content/posts/linux-vs-freebsd-vs-openbsd.md
@@ -99,5 +99,5 @@ Thanks for reading and a special *thank you* to everyone who helped on Reddit, l
 - [Alpine Linux](https://alpinelinux.org/about/)
 - [OpenBSD Goals](https://www.openbsd.org/goals.html)
 - [OpenBSD Why Use](https://www.openbsd.org/faq/faq1.html#WhyUse)
-- [FreeBSD Features](https://www.freebsd.org/features/)
+- FreeBSD Project [goal](https://docs.freebsd.org/en/books/faq/#FreeBSD-goals) and [features](https://www.freebsd.org/features/)
 


### PR DESCRIPTION
Neither new Reddit nor the Reddit app makes it easy to discover cross-posts and commentaries. So, alongside a link to the original in /r/BSD, link to the cross-post in /r/freebsd.

Add links to discussions of _Quare FreeBSD?_.

Adjust the _OpenBSD Why Use_ line, with regard to a nonexistent anchor.

Add a link to the goal of the FreeBSD Project, which is more modern than the set of focus areas at the features page.

